### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "6"
-  - "5"
-  - "4"
-  - "0.12"
-  - "0.11"
+  - node  # latest stable Node.js release
+  - lts/* # latest LTS Node.js release
+  - 6


### PR DESCRIPTION
Build was broken for 0.11 and 0.12 (AVA requires at least node 6 nowadays).
Updated versions to all [currently supported node versions][1].

[1]: https://github.com/nodejs/Release#release-schedule